### PR TITLE
Release 1.3.0

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+exclude_paths:
+  - '*.md'
+  - 'docs/*'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /dist/
 /build/
 /dhunter.egg-info/
+.dhunter
+.dhunterignore

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
 
 ## Features ##
 
- * Content based file matching
+ * Content based file matching (sha256)
  * Designed to work with lot of data:
-   * caches folder scaning results for quick reuse
+   * caches folder scaning results for quick reuse/rescan
    * directory scanning can be aborted and **resumed** at any moment
  * Smart content filters
    * Ignores zero length files and symlinks

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
  * [Requirements and installation](docs/install.md)
  * [Bugs reports and contributions](docs/contribute.md)
  * [Credits and license](#credits-and-license)
- * [What's new?](docs/CHANGES.md)
+ * [Changelog](docs/CHANGES.md)
 
 ## Introduction ##
 

--- a/dhunter/core/args_base.py
+++ b/dhunter/core/args_base.py
@@ -36,7 +36,7 @@ class ArgsBase(object):
 
         return parser
 
-    def _add_filter_option_group(self, parser: argparse.ArgumentParser) -> None:
+    def _add_filter_option_group(self, parser: argparse.ArgumentParser) -> argparse._ArgumentGroup:
         group = parser.add_argument_group('Filters')
         group.add_argument('-min', '--min',
                            metavar='SIZE', action='store', dest='min_size', nargs=1, type=str,
@@ -54,18 +54,9 @@ class ArgsBase(object):
                                 'Zero means no max size limit. Default value is {}.'.format(
                                Const.FILE_FILTER_SIZE_MAX))
 
-        group.add_argument('-exdir', '--exdir',
-                           metavar='REGEXP', action='append', dest='exclude_dir_regexps', nargs=1, type=str,
-                           help='Exclude directories (paths) matching specified regular expression. '
-                                'Option can be used multiple times for multiple patters. Also always quote '
-                                'your patterns to prevent shell expansion.')
-        group.add_argument('-exfile', '--exfile',
-                           metavar='REGEXP', action='append', dest='exclude_file_regexps', nargs=1, type=str,
-                           help='Exclude filenames matching specified regular expression. '
-                                'Option can be used multiple times for multiple patters. Also always quote '
-                                'your patterns to prevent shell expansion.')
+        return group
 
-    def _add_other_option_group(self, parser: argparse.ArgumentParser) -> None:
+    def _add_other_option_group(self, parser: argparse.ArgumentParser) -> argparse._ArgumentGroup:
         group = parser.add_argument_group('Other')
         group.add_argument('-f', '-force', '--force',
                            action='store_true', dest='force',
@@ -85,6 +76,8 @@ class ArgsBase(object):
         group.add_argument('-debug-verbose', '--debug-verbose',
                            action='store_true', dest='debug_verbose',
                            help='Enables verbose debug output (implies --debug).')
+
+        return group
 
     def _debug_check(self, args: argparse.Namespace) -> None:
         import os

--- a/dhunter/core/args_base.py
+++ b/dhunter/core/args_base.py
@@ -51,8 +51,19 @@ class ArgsBase(object):
                                 'Supported format <VAL><UNIT> where val is positive integer, and '
                                 'unit is one letter (case insensitive): b for bytes, k for KiB, '
                                 'm for MiB, g for GiB and t for TiB. i.e. "1024" = "1024b" = "1k". '
-                                'Default value is {}. Zero means no max size limit.'.format(
+                                'Zero means no max size limit. Default value is {}.'.format(
                                Const.FILE_FILTER_SIZE_MAX))
+
+        group.add_argument('-exdir', '--exdir',
+                           metavar='REGEXP', action='append', dest='exclude_dir_regexps', nargs=1, type=str,
+                           help='Exclude directories (paths) matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
+        group.add_argument('-exfile', '--exfile',
+                           metavar='REGEXP', action='append', dest='exclude_file_regexps', nargs=1, type=str,
+                           help='Exclude filenames matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
 
     def _add_other_option_group(self, parser: argparse.ArgumentParser) -> None:
         group = parser.add_argument_group('Other')

--- a/dhunter/core/args_base.py
+++ b/dhunter/core/args_base.py
@@ -52,7 +52,7 @@ class ArgsBase(object):
                                 'unit is one letter (case insensitive): b for bytes, k for KiB, '
                                 'm for MiB, g for GiB and t for TiB. i.e. "1024" = "1024b" = "1k". '
                                 'Zero means no max size limit. Default value is {}.'.format(
-                               Const.FILE_FILTER_SIZE_MAX))
+                                 Const.FILE_FILTER_SIZE_MAX))
 
         return group
 

--- a/dhunter/core/config_base.py
+++ b/dhunter/core/config_base.py
@@ -35,6 +35,8 @@ class ConfigBase(object):
         self.filter: Filter or None = None
         self.dont_save_dot_file: bool = False
         self.command: str or None = None
+        self.exclude_dir_regexps: List[str] = []
+        self.exclude_file_regexps: List[str] = []
 
     @staticmethod
     @abstractmethod

--- a/dhunter/core/const.py
+++ b/dhunter/core/const.py
@@ -17,7 +17,7 @@ from typing import List
 class Const(object):
     APP_NAME: str = 'dhunter'
     APP_URL: str = 'https://github.com/MarcinOrlowski/dhunter'
-    APP_VERSION: str = '1.2.0'
+    APP_VERSION: str = '1.3.0'
 
     FIELD_TYPE: str = '_type'
     FIELD_VERSION: str = '_version'

--- a/dhunter/core/db_base.py
+++ b/dhunter/core/db_base.py
@@ -64,8 +64,8 @@ class DbBase(object):
     def insert(self, item):
         raise NotImplementedError
 
-    def replace(self, item):
+    def replace(self):
         raise NotImplementedError
 
-    def remove(self, item):
+    def remove(self):
         raise NotImplementedError

--- a/dhunter/core/file_hash.py
+++ b/dhunter/core/file_hash.py
@@ -271,15 +271,12 @@ class FileHash(HashBase, DbBase):
 
         self.__create_tables(queries)
 
-    def replace(self, file_hash) -> None:
-        if file_hash is None or not isinstance(file_hash, FileHash):
-            raise ValueError('Expecting FileHash instance, received {type}'.format(type=type(file_hash)))
-
+    def replace(self) -> None:
         self.__db_connect()
 
         sql = 'REPLACE INTO files(`path`,`name`,`hash`,`size`,`mtime`,`ctime`,`inode`) VALUES(?,?,?,?,?,?,?)'
-        dir_path = os.path.dirname(file_hash.path)
-        vals = (dir_path, file_hash.name, file_hash.hash, file_hash.size, file_hash.mtime,
-                file_hash.ctime, file_hash.inode)
+        dir_path = os.path.dirname(self.path)
+        vals = (dir_path, self.name, self.hash, self.size, self.mtime, self.ctime, self.inode)
+
         cur = self.__db.cursor()
         cur.execute(sql, vals)

--- a/dhunter/core/filter.py
+++ b/dhunter/core/filter.py
@@ -38,10 +38,23 @@ class Filter(object):
 
     def __init__(self, config: ConfigBase):
         self._file_name_blacklist = Filter._BASE_FILE_NAME_BLACKLIST
+        self._append_regexp(self._file_name_blacklist, config.exclude_file_regexps)
+
         self._dir_name_blacklist = Filter._BASE_DIR_NAME_BLACKLIST
+        self._append_regexp(self._dir_name_blacklist, config.exclude_dir_regexps)
 
         self.min_size = config.min_size
         self.max_size = config.max_size
+
+    def _append_regexp(self, to, regexps):
+        if regexps:
+            try:
+                for pattern in regexps:
+                    re.compile(pattern)
+                    to.append(pattern)
+            except re.error:
+                from .log import Log
+                Log.abort('Invalid pattern: {}'.format(pattern))
 
     @property
     def min_size(self) -> int:

--- a/dhunter/core/filter.py
+++ b/dhunter/core/filter.py
@@ -46,15 +46,19 @@ class Filter(object):
         self.min_size = config.min_size
         self.max_size = config.max_size
 
-    def _append_regexp(self, to, regexps):
+    def _append_regexp(self, to: List[str], regexps: List[str] or None):
+        """Appends new regexp rules to existing blacklists."""
         if regexps:
             try:
                 for pattern in regexps:
                     re.compile(pattern)
-                    to.append(pattern)
+                    if pattern not in to:
+                        to.append(pattern)
             except re.error:
                 from .log import Log
                 Log.abort('Invalid pattern: {}'.format(pattern))
+
+    # ------------------------------------------------------------------------------------------------------------
 
     @property
     def min_size(self) -> int:

--- a/dhunter/core/filter.py
+++ b/dhunter/core/filter.py
@@ -58,6 +58,7 @@ class Filter(object):
                         to.append(pattern)
             except re.error:
                 from .log import Log
+                # noinspection PyUnboundLocalVariable
                 Log.abort('Invalid pattern: {}'.format(pattern))
 
     # ------------------------------------------------------------------------------------------------------------

--- a/dhunter/core/filter.py
+++ b/dhunter/core/filter.py
@@ -38,10 +38,12 @@ class Filter(object):
 
     def __init__(self, config: ConfigBase):
         self._file_name_blacklist = Filter._BASE_FILE_NAME_BLACKLIST
-        self._append_regexp(self._file_name_blacklist, config.exclude_file_regexps)
+        if hasattr(config, 'exclude_file_regexps'):
+            self._append_regexp(self._file_name_blacklist, config.exclude_file_regexps)
 
         self._dir_name_blacklist = Filter._BASE_DIR_NAME_BLACKLIST
-        self._append_regexp(self._dir_name_blacklist, config.exclude_dir_regexps)
+        if hasattr(config, 'exclude_dir_regexps'):
+            self._append_regexp(self._dir_name_blacklist, config.exclude_dir_regexps)
 
         self.min_size = config.min_size
         self.max_size = config.max_size

--- a/dhunter/core/hash_manager.py
+++ b/dhunter/core/hash_manager.py
@@ -17,7 +17,6 @@ import typing
 
 from .config_base import ConfigBase
 from .dir_hash import DirHash
-from .file_hash import FileHash
 
 
 class HashManager(object):

--- a/dhunter/core/hash_manager.py
+++ b/dhunter/core/hash_manager.py
@@ -182,29 +182,6 @@ class HashManager(object):
         self._db_connect()
         _ = [self._db.cursor().execute(query) for query in queries]
 
-    def _replace_file_hash(self, file_hash: FileHash or None) -> None:
-        if self._use_db is False:
-            return
-
-        from .log import Log
-
-        Log.level_push()
-        Log.dd('insert file hash({})'.format(file_hash.name))
-
-        if file_hash is None or not isinstance(file_hash, FileHash):
-            raise ValueError('Expecting FileHash instance, received {type}'.format(type=type(file_hash)))
-
-        self.db_init()
-
-        sql = 'REPLACE INTO files(`path`,`name`,`hash`,`size`,`mtime`,`ctime`,`inode`) VALUES(?,?,?,?,?,?,?)'
-        dir_path = os.path.dirname(file_hash.path)
-        vals = (dir_path, file_hash.name, file_hash.hash, file_hash.size, file_hash.mtime,
-                file_hash.ctime, file_hash.inode)
-        cur = self._db.cursor()
-        cur.execute(sql, vals)
-
-        Log.level_pop()
-
     def insert(self, dir_hash: DirHash or None) -> None:
         if self._use_db is False:
             return
@@ -230,7 +207,7 @@ class HashManager(object):
         from .const import Const
         for _, file_hash in dir_hash.cache.items():
             if file_hash.name not in [Const.FILE_DOT_IGNORE, Const.FILE_DOT_DHUNTER]:
-                self._replace_file_hash(file_hash)
+                file_hash.replace()
         self._db.commit()
 
     def get_stats(self) -> (int, int, int):

--- a/dhunter/hunter/args.py
+++ b/dhunter/hunter/args.py
@@ -56,7 +56,18 @@ class Args(ArgsBase):
                            help='Limit number of shown results to given count. '
                                 'Default is 0, which means no limits.')
 
-        self._add_filter_option_group(parser)
+        group = self._add_filter_option_group(parser)
+        group.add_argument('-exdir', '--exdir',
+                           metavar='REGEXP', action='append', dest='exclude_dir_regexps', nargs=1, type=str,
+                           help='Exclude directories (paths) matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
+        group.add_argument('-exfile', '--exfile',
+                           metavar='REGEXP', action='append', dest='exclude_file_regexps', nargs=1, type=str,
+                           help='Exclude filenames matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
+
         self._add_other_option_group(parser)
 
         # this trick is to enforce stacktrace in case parse_args() fail (which should normally not happen)

--- a/dhunter/hunter/args.py
+++ b/dhunter/hunter/args.py
@@ -56,18 +56,7 @@ class Args(ArgsBase):
                            help='Limit number of shown results to given count. '
                                 'Default is 0, which means no limits.')
 
-        group = self._add_filter_option_group(parser)
-        group.add_argument('-exdir', '--exdir',
-                           metavar='REGEXP', action='append', dest='exclude_dir_regexps', nargs=1, type=str,
-                           help='Exclude directories (paths) matching specified regular expression. '
-                                'Option can be used multiple times for multiple patters. Also always quote '
-                                'your patterns to prevent shell expansion.')
-        group.add_argument('-exfile', '--exfile',
-                           metavar='REGEXP', action='append', dest='exclude_file_regexps', nargs=1, type=str,
-                           help='Exclude filenames matching specified regular expression. '
-                                'Option can be used multiple times for multiple patters. Also always quote '
-                                'your patterns to prevent shell expansion.')
-
+        self._add_filter_option_group(parser)
         self._add_other_option_group(parser)
 
         # this trick is to enforce stacktrace in case parse_args() fail (which should normally not happen)

--- a/dhunter/hunter/hunter.py
+++ b/dhunter/hunter/hunter.py
@@ -79,6 +79,7 @@ class Hunter(object):
 
     # ------------------------------------------------------------------------------------------------------------
 
+    # noinspection PyUnusedLocal
     def clean_db(self, config: ConfigBase) -> None:
         dead_rowids = []
 
@@ -104,8 +105,8 @@ class Hunter(object):
         if dead_rowids:
             Log.level_push('Updating database')
             cursor = hm.db.cursor()
-            for id in dead_rowids:
-                cursor.execute('DELETE FROM `files` WHERE `ROWID`=?', (id,))
+            for row_id in dead_rowids:
+                cursor.execute('DELETE FROM `files` WHERE `ROWID`=?', (row_id,))
             Log.level_pop()
 
     # ------------------------------------------------------------------------------------------------------------

--- a/dhunter/scanner/args.py
+++ b/dhunter/scanner/args.py
@@ -35,8 +35,8 @@ class Args(ArgsBase):
                            help='Name of project database file to create.')
 
         group.add_argument(
-                metavar='DIR', action='store', dest='src_dirs', nargs='+',
-                help='Directories to process.')
+            metavar='DIR', action='store', dest='src_dirs', nargs='+',
+            help='Directories to process.')
 
         group = parser.add_argument_group('Misc')
         group.add_argument('-r', '-rehash', '--rehash',
@@ -46,7 +46,7 @@ class Args(ArgsBase):
         group.add_argument('-cmd', '--cmd', '--command',
                            action='store', dest='command', nargs=1, metavar="COMMAND", default=Const.CMD_SCAN,
                            help='Action to execute. Commands are: %s. ' % ', '.join(Const.SCANNER_CMDS) +
-                           'Default command is %s' % Const.CMD_SCAN)
+                                'Default command is %s' % Const.CMD_SCAN)
         group.add_argument('-ro', '--ro', '--read-only',
                            action='store_true', dest='dont_save_dot_file',
                            help='Tells the scanner to treat all the folders as read only and do not '
@@ -58,7 +58,18 @@ class Args(ArgsBase):
                            action='store_true', dest='no_recursive',
                            help='Do not scan subdirectories.')
 
-        self._add_filter_option_group(parser)
+        group = self._add_filter_option_group(parser)
+        group.add_argument('-exdir', '--exdir',
+                           metavar='REGEXP', action='append', dest='exclude_dir_regexps', nargs=1, type=str,
+                           help='Exclude directories (paths) matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
+        group.add_argument('-exfile', '--exfile',
+                           metavar='REGEXP', action='append', dest='exclude_file_regexps', nargs=1, type=str,
+                           help='Exclude filenames matching specified regular expression. '
+                                'Option can be used multiple times for multiple patters. Also always quote '
+                                'your patterns to prevent shell expansion.')
+
         self._add_other_option_group(parser)
 
         # this trick is to enforce stacktrace in case parse_args() fail (which should normally not happen)

--- a/dhunter/scanner/config.py
+++ b/dhunter/scanner/config.py
@@ -43,6 +43,8 @@ class Config(ConfigBase):
             'force',
             'relative_paths',
             'no_recursive',
+            'exclude_dir_regexps',
+            'exclude_file_regexps',
         ]
         for key in _keys:
             config.__setattr__(key, getattr(args, key))
@@ -58,6 +60,16 @@ class Config(ConfigBase):
                 Log.abort('Project file already exists.')
             else:
                 os.unlink(config.db_file)
+
+        if config.exclude_file_regexps is not None:
+            config.exclude_file_regexps = [x for y in config.exclude_file_regexps for x in y]
+        else:
+            config.exclude_file_regexps = []
+
+        if config.exclude_dir_regexps is not None:
+            config.exclude_dir_regexps = [x for y in config.exclude_dir_regexps for x in y]
+        else:
+            config.exclude_dir_regexps = []
 
         if config.command is not None:
             config.command = config.command

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -3,8 +3,8 @@
 
 ## Changelog ##
 
-dev
----
+v1.3.0 (2019-07-31)
+-------------------
  * Now uses full absolute path for each item strored in project db file
  * dhunter: automatically removes dead entries from used DB if they hit the filter
  * dhunter: added `cleandb` command that removes dead entries from project DB

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -12,6 +12,7 @@ dev
  * dscan: now supports `--force` to overwrite existing database file
  * dscan: added `--relative-paths` option
  * dscan: added `--no-recursive` option
+ * dscan: added support for custom file (`--exfile`) and dir exclusion (`--exdir`) rules
 
 v1.2.0 (2019-03-11)
 -------------------

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,6 +76,21 @@
     * .htaccess
     * .htpasswd
     * .gitignore
+
+##### Custom filters #####
+
+ You can provide own regular expressions for both file and directory filtering purposes by using
+ `--exdir` and `--exfile` options, i.e:
+
+    dscan --exdir ".*/cache" /disk1/pictures
+
+ would scan `/disk1/pictures` and skip all "cache" named directories. If you want to provide more
+ than one custom rules, you can use said switches more than once, i.e.
+
+    dscan --exdir ".*/cache" --exdir ".*/foo" /disk1/pictures
+
+ **NOTE:** You should always quote your regular expression if you use special characters that
+ could be expanded by your shell.
  
 ### Hunting ###
 


### PR DESCRIPTION
 * Now uses full absolute path for each item strored in project db file
 * dhunter: automatically removes dead entries from used DB if they hit the filter
 * dhunter: added `cleandb` command that removes dead entries from project DB
 * dhunter: now yields proper warning when source dir is a symlink
 * dscan: now supports `--force` to overwrite existing database file
 * dscan: added `--relative-paths` option
 * dscan: added `--no-recursive` option
 * dscan: added support for custom file (`--exfile`) and dir exclusion (`--exdir`) rule